### PR TITLE
apiKey config

### DIFF
--- a/src/Fcm.php
+++ b/src/Fcm.php
@@ -15,4 +15,42 @@ class Fcm extends Gcm
         
         $this->client = new Client();
     }
+
+    protected function addRequestFields($deviceTokens,$message)
+    {
+        $return = array();
+        if(count($deviceTokens)) {
+            $return['to'] = $deviceTokens[0];
+        }
+
+        if(isset($message['to'])) {
+            $return['to'] = $message['to'];
+            unset($message['to']);
+        }
+
+        if(isset($message['notification'])) {
+            $return['notification'] = $message['notification'];
+            unset($message['notification']);
+        }
+
+        if(isset($message['data'])) {
+            $return['data'] = $message['data'];
+        } else if(count($message)) {
+            $return['data'] = $message;
+        }
+
+        return $return;
+    }
+
+    public function send(array $deviceTokens,array $message)
+    {
+        if(count($deviceTokens) > 1) {
+            foreach($deviceTokens as $deviceToken) {
+                parent::send([$deviceToken], $message);
+            }
+        } else {
+            parent::send($deviceTokens, $message);
+        }
+    }
+
 }

--- a/src/Fcm.php
+++ b/src/Fcm.php
@@ -12,6 +12,7 @@ class Fcm extends Gcm
         $this->url = 'https://fcm.googleapis.com/fcm/send';
 
         $this->config = $this->initializeConfig('fcm');
+        $this->apiKey = $this->config['apiKey'];
         
         $this->client = new Client();
     }

--- a/src/PushNotification.php
+++ b/src/PushNotification.php
@@ -7,14 +7,14 @@ class PushNotification
 
     /**
      * Push Service Provider
-     * @var
+     * @var PushService
      */
     protected $service;
 
     /**
      * List of the available Push service providers
      *
-     * @var array
+     * @var PushService[]
      */
     protected $servicesList = [
         'gcm' => Gcm::class,

--- a/src/PushService.php
+++ b/src/PushService.php
@@ -2,7 +2,13 @@
 
 namespace Edujugon\PushNotification;
 
-
+/**
+ * abstract Class PushService
+ * Serves as superclass for Apn, Gcm and Fcm
+ *
+ * @property mixed feedback
+ * @package Edujugon\PushNotification
+ */
 abstract class PushService
 {
 
@@ -113,4 +119,6 @@ abstract class PushService
         return property_exists($this,$property) ? $this->$property : null;
     }
 
+    abstract public function getUnregisteredDeviceTokens(array $devices_token);
+    abstract public function send(array $deviceTokens,array $message);
 }


### PR DESCRIPTION
Currently, when setting apiKey by configuration file, it isn't recognized. This is corrected here.