### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,10 +75,10 @@ You can dynamically update those values or adding new ones calling the method se
 
 The default configuration parameters for **APN** are:
 
-*   certificate => __DIR__ . '/iosCertificates/yourCertificate.pem'
-*   passPhrase => 'MyPassPhrase'
-*   passFile => __DIR__ . '/iosCertificates/yourKey.pem' //Optional
-*   dry_run => false
+*   ```certificate => __DIR__ . '/iosCertificates/yourCertificate.pem'```
+*   ```passPhrase => 'MyPassPhrase'```
+*   ```passFile => __DIR__ . '/iosCertificates/yourKey.pem' //Optional```
+*   ```dry_run => false```
 
 Also you can update those values and add more dynamically
 


### PR DESCRIPTION
Add code syntax to correctly show configuration parameters.

The DIR constant was incorrectly shown in the readme. Because of markdown syntax, it was shown as bold ( __DIR__ ) instead of the PHP constant ( ```__DIR__``` )