### PR TITLE
apn.php: avoid recursion on connection failure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,12 +88,14 @@ The default configuration parameters for **APN** are:
 *   passPhrase => 'MyPassPhrase'
 *   passFile => __DIR__ . '/iosCertificates/yourKey.pem' //Optional
 *   dry_run => false
+*   connection_attempts => 3 //Optional
 
 Also you can update those values and add more dynamically
 
     $push->setConfig([
         'passPhrase' => 'NewPass',
         'custom' => 'MycustomValue',
+        'connection_attempts' => 3,
         'dry_run' => true
     ]);
 
@@ -102,6 +104,21 @@ Even you may update the url of the Push Service dynamically like follows:
     $puhs->setUrl('http://newPushServiceUrl.com');
 
 > Not update the url unless it's really necessary.
+
+You can specify the number of client-side attempts to APN before giving
+up.  The default amount is 3 attempts.  You can override this value by
+specifying `connection_attempts` in `setConfig()` assoc-array.  Keep in
+mind the default number of requested attempts is 3.
+
+If you prefer to retry indefinitely, set `connection_attempts` to zero.
+
+    $push->setConfig([
+        'passPhrase' => 'NewPass',
+        'custom' => 'MycustomValue',
+        'connection_attempts' => 0,
+        'dry_run' => true
+    ]);
+
 
 ## Usage
 

--- a/tests/PushNotificationTest.php
+++ b/tests/PushNotificationTest.php
@@ -289,4 +289,68 @@ class PushNotificationTest extends PHPUnit_Framework_TestCase {
 
         //var_dump($tokens);
     }
+
+    /** @test */
+    public function apn_connection_attempts_default() {
+        $push = new PushNotification('apn');
+
+        $push->setConfig(['dry_run' => true]);
+
+        $key = 'connection_attempts';
+        $this->assertArrayNotHasKey($key, $push->config);
+    }
+
+    /** @test */
+    public function set_apn_connect_attempts_override_default() {
+        $push = new PushNotification('apn');
+
+        $expected = 0;
+        $push->setConfig([
+            'dry_run' => true,
+            'connection_attempts' => $expected,
+        ]);
+
+        $key = 'connection_attempts';
+        $this->assertArrayHasKey($key, $push->config);
+        $this->assertEquals($expected, $push->config[$key]);
+    }
+
+    /** @test */
+    public function apn_connect_attempts_bailout_badcert() {
+        $push = new PushNotification('apn');
+
+        $tmp_name = tempnam(sys_get_temp_dir(), 'apn-tmp');
+        $fh = fopen($tmp_name, 'w');
+        fwrite($fh, 'badcert');
+        fclose($fh);
+
+        $expected = 0;
+
+        // ZZZ: intentional failure use-case so let's not
+        // waste time attemping to push with a bad cert.
+        $push->setConfig([
+            'dry_run' => true,
+            'connection_attempts' => 1,
+            'certificate' => $tmp_name,
+        ]);
+
+        $message = [
+            'aps' => [
+                'alert' => [
+                    'title' => '1 Notification test',
+                    'body' => 'Just for testing purposes'
+                ],
+                'sound' => 'default'
+            ]
+        ];
+
+        $push->setMessage($message)
+            ->setDevicesToken(['507e3adaf433ae3e6234f35c82f8a43ad0d84218bff08f16ea7be0869f066c0312']);
+
+        $push = $push->send();
+        $this->assertInstanceOf('stdClass', $push->getFeedback());
+
+        unlink($tmp_name);
+    }
+
 }


### PR DESCRIPTION
Currently when Apn.php attempts to connect to apple push services we
attempt to re-try caught exceptions if one is thrown.  However, in
situations where a push certificate is invalid or expired we run into
infinite recursion constantly re-trying the connection without providing
any feedback.

The following will set a limit on the number of times we may re-try.
Configurable if users defined 'connection_attempts'.

Signed-off-by: Jamie Couture <jamie.couture@crowdspark.com>