### PR TITLE
Customize the badge number over Notification Channels.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -545,6 +545,16 @@ public function toApn($notifiable)
 }
 ```
 
+#### Customizing The Badge Number
+```php
+public function toApn($notifiable)
+{
+  return (new PushMessage)
+        ->body('Hello world')
+        ->sound('default')
+        ->badge(7);
+}
+
 #### Passing Service Config
 ```php
 public function toApn($notifiable)

--- a/src/Channels/ApnChannel.php
+++ b/src/Channels/ApnChannel.php
@@ -26,6 +26,7 @@ class ApnChannel extends PushChannel
                     'body' => $message->body,
                 ],
                 'sound' => $message->sound,
+                'badge' => $message->badge,
             ],
         ];
 

--- a/src/Messages/PushMessage.php
+++ b/src/Messages/PushMessage.php
@@ -20,6 +20,11 @@ class PushMessage
     public $sound = 'default';
 
     /**
+     * @var integer
+     */
+    public $badge;
+
+    /**
      * @var array
      */
     public $extra = [];
@@ -75,6 +80,19 @@ class PushMessage
     public function sound($sound)
     {
         $this->sound = $sound;
+
+        return $this;
+    }
+
+    /**
+     * Set the notification badge.
+     *
+     * @param  integer $badge
+     * @return void
+     */
+    public function badge($badge)
+    {
+        $this->badge = $badge;
 
         return $this;
     }


### PR DESCRIPTION
Though there is support for sending an apn request with an attached badge number, for those who decide to make use of Laravel Notifications, there is no way in a notification to set the badge.  The attached code adds set methods to the PushMessage class, and passes them through the ApnChannel.  Also updated the docs accordingly.