### PR TITLE
bitmask of JSON_BIGINT_AS_STRING

### DIFF
--- a/src/Gcm.php
+++ b/src/Gcm.php
@@ -150,7 +150,7 @@ class Gcm extends PushService implements PushServiceInterface
 
             $json = $result->getBody();
 
-            $this->setFeedback(json_decode($json));
+            $this->setFeedback(json_decode($json , false , 512 , JSON_BIGINT_AS_STRING));
 
             return $this->feedback;
 


### PR DESCRIPTION
Using JSON_BIGINT_AS_STRING as bitmask to prevent large integers convertion to float type

Issue reference #63