### PR TITLE
To handle FCM notification in backgrounded Android applications

### DIFF
--- a/src/Channels/ApnChannel.php
+++ b/src/Channels/ApnChannel.php
@@ -25,6 +25,7 @@ class ApnChannel extends PushChannel
                     'title' => $message->title,
                     'body' => $message->body,
                 ],
+                'category' => $message->category,
                 'sound' => $message->sound,
             ],
         ];

--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -20,7 +20,7 @@ class GcmChannel extends PushChannel
     protected function buildData(PushMessage $message)
     {
         $data = [];
-        if($message->title != null || $message->body != null || $message->click_action)
+        if($message->title != null || $message->body != null || $message->click_action != null)
         {
             $data = [
                 'notification' => [

--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -19,14 +19,18 @@ class GcmChannel extends PushChannel
      */
     protected function buildData(PushMessage $message)
     {
-        $data = [
-            'notification' => [
-                'title' => $message->title,
-                'body' => $message->body,
-                'sound' => $message->sound,
-                'click_action' => $message->click_action,
-            ],
-        ];
+        $data = [];
+        if($message->title != null || $message->body != null || $message->sound != null || $message->click_action)
+        {
+            $data = [
+                'notification' => [
+                    'title' => $message->title,
+                    'body' => $message->body,
+                    'sound' => $message->sound,
+                    'click_action' => $message->click_action,
+                ],
+            ];
+        }
 
         if (! empty($message->extra)) {
             $data['data'] = $message->extra;

--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -24,6 +24,7 @@ class GcmChannel extends PushChannel
                 'title' => $message->title,
                 'body' => $message->body,
                 'sound' => $message->sound,
+                'click_action' => $message->click_action,
             ],
         ];
 

--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -3,7 +3,6 @@
 namespace Edujugon\PushNotification\Channels;
 
 use Edujugon\PushNotification\Messages\PushMessage;
-use Illuminate\Support\Facades\Log;
 
 class GcmChannel extends PushChannel
 {
@@ -21,7 +20,7 @@ class GcmChannel extends PushChannel
     protected function buildData(PushMessage $message)
     {
         $data = [];
-        if($message->title != null || $message->body != null || $message->sound != null || $message->click_action)
+        if($message->title != null || $message->body != null || $message->click_action)
         {
             $data = [
                 'notification' => [
@@ -36,8 +35,6 @@ class GcmChannel extends PushChannel
         if (! empty($message->extra)) {
             $data['data'] = $message->extra;
         }
-
-        Log::alert(dd($data));
 
         return $data;
     }

--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -3,6 +3,7 @@
 namespace Edujugon\PushNotification\Channels;
 
 use Edujugon\PushNotification\Messages\PushMessage;
+use Illuminate\Support\Facades\Log;
 
 class GcmChannel extends PushChannel
 {
@@ -35,6 +36,8 @@ class GcmChannel extends PushChannel
         if (! empty($message->extra)) {
             $data['data'] = $message->extra;
         }
+
+        Log::alert(dd($data));
 
         return $data;
     }

--- a/src/Channels/PushChannel.php
+++ b/src/Channels/PushChannel.php
@@ -5,6 +5,7 @@ use Edujugon\PushNotification\Events\NotificationPushed;
 use Edujugon\PushNotification\Messages\PushMessage;
 use Edujugon\PushNotification\PushNotification;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Log;
 
 abstract class PushChannel
 {
@@ -39,6 +40,8 @@ abstract class PushChannel
         $message = $this->buildMessage($notifiable, $notification);
 
         $data = $this->buildData($message);
+
+        Log::info($message);
 
         $this->push($this->pushServiceName(), $to, $data, $message);
     }

--- a/src/Channels/PushChannel.php
+++ b/src/Channels/PushChannel.php
@@ -5,7 +5,6 @@ use Edujugon\PushNotification\Events\NotificationPushed;
 use Edujugon\PushNotification\Messages\PushMessage;
 use Edujugon\PushNotification\PushNotification;
 use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Log;
 
 abstract class PushChannel
 {
@@ -40,8 +39,6 @@ abstract class PushChannel
         $message = $this->buildMessage($notifiable, $notification);
 
         $data = $this->buildData($message);
-
-        Log::info($message);
 
         $this->push($this->pushServiceName(), $to, $data, $message);
     }

--- a/src/Messages/PushMessage.php
+++ b/src/Messages/PushMessage.php
@@ -20,6 +20,16 @@ class PushMessage
     public $sound = 'default';
 
     /**
+     * @var string
+     */
+    public $click_action;
+
+    /**
+     * @var string
+     */
+    public $category;
+
+    /**
      * @var integer
      */
     public $badge;
@@ -80,6 +90,32 @@ class PushMessage
     public function sound($sound)
     {
         $this->sound = $sound;
+
+        return $this;
+    }
+
+    /**
+     * The action associated with a user click on the notification.(Android) 
+     *
+     * @param  string $click_action
+     * @return $this
+     */
+    public function clickAction($click_action)
+    {
+        $this->click_action = $click_action;
+        
+        return $this;
+    }
+
+    /**
+     * The action associated with a user click on the notification.(iOS) 
+     *
+     * @param  string $click_action
+     * @return $this
+     */
+    public function category($category)
+    {
+        $this->category = $category;
 
         return $this;
     }


### PR DESCRIPTION
Added click_action for android and category for iOS in order to set action when the status bar notification is clicked. Moreover, changed GcmChannel buildData method to send data without the 'notifications' parameter in order to solve the problem mentioned in the following article:
**[How to handle FCM notification in backgrounded Android applications](https://medium.com/@shayan.ta69/how-to-handle-fcm-notification-in-backgrounded-android-applications-29229c4f9975)**