### PR TITLE
FCM and GCM not sending the badge number via channel

### DIFF
--- a/src/Channels/GcmChannel.php
+++ b/src/Channels/GcmChannel.php
@@ -29,6 +29,11 @@ class GcmChannel extends PushChannel
                     'click_action' => $message->click_action,
                 ],
             ];
+
+            // Set custom badge number when isset in PushMessage
+            if (! empty($message->badge)) {
+                $data['notification']['badge'] = $message->badge;
+            }
         }
 
         if (! empty($message->extra)) {


### PR DESCRIPTION
As found here, both FCM and GCM support custom badge numbers:
https://distriqt.github.io/ANE-PushNotifications/m.FCM-GCM%20Payload

Apparently the channel does not send the badge number, so I create a simple fix.
