### PR TITLE
remove "minimum-stability": "dev" from `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,5 @@
                 "PushNotification": "Edujugon\\PushNotification\\Facades\\PushNotification"
             }
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Having `"minimum-stability": "dev"` causes Composer to download "dev-master' for every required package. This is absolutely unnecessary. In particular: it slows down the Travis build.