### PR TITLE
Updated the GCM API URL to the FCM legacy URL

### DIFF
--- a/src/Gcm.php
+++ b/src/Gcm.php
@@ -28,7 +28,7 @@ class Gcm extends PushService implements PushServiceInterface
      */
     public function __construct()
     {
-        $this->url = 'https://android.googleapis.com/gcm/send';
+        $this->url = 'https://fcm.googleapis.com/fcm/send';
         
         $this->config = $this->initializeConfig('gcm');
         $this->client = new Client;


### PR DESCRIPTION
The old URL is no longer working, it redirects to documentation stating that we should use this URL.

Documentation here:  https://firebase.google.com/docs/cloud-messaging/http-server-ref