### PR TITLE
Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php" : "^7.1.3",
-        "guzzlehttp/guzzle": "^6.3",
-        "illuminate/support": "~5.8 || ^6.0 || ^7.0",
-        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0"
+        "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
+        "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.0"


### PR DESCRIPTION
This PR adds support for recently released [Laravel 8](https://github.com/laravel/framework/releases/tag/v8.0.0)