### PR TITLE
Remove undesired character

### DIFF
--- a/src/Gcm.php
+++ b/src/Gcm.php
@@ -121,7 +121,7 @@ class Gcm extends PushService implements PushServiceInterface
     {
         return [
             'Authorization' => 'key=' . $this->config['apiKey'],
-            'Content-Type:' =>'application/json'
+            'Content-Type' =>'application/json'
         ];
     }
 


### PR DESCRIPTION
The additional colon character after the Content-Type string will result in folowing error in HTTP Request:
"Content-Type:" is not valid header name
Of course the right header name is "Content-Type" without the colon character.