### PR TITLE
Add FCM HTTP V1 service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": "^7.1.3|^8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
-        "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
-        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
+        "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "google/apiclient": "^2.15"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": "^7.1.3 || ^8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
-        "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "google/apiclient": "^2.15"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php": "^7.1.3|^8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
         "illuminate/support": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
-        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0"
+        "illuminate/notifications": "~5.8 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
+        "google/apiclient": "^2.15"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.0  || ^9.0"

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ This is an easy to use package to send push notification.
 
 * GCM
 * FCM
+* FCMV1
 * APN
 
 ## Installation
@@ -58,6 +59,28 @@ $push->setConfig([
     'time_to_live' => 3
 ]);
 ```
+
+The default configuration parameters for **FCMV1** are :
+
+*   ```priority => 'normal'```
+*   ```dry_run => false```
+*   ```projectId => 'my-project-id'```
+*   ```jsonFile => __DIR__ . '/fcmCertificates/file.json'```
+
+You can dynamically update those values or adding new ones calling the method setConfig like so:
+```php
+$push->setConfig([
+    'priority' => 'high',
+    'projectId' => 'my-real-project-id',
+    'jsonFile' => 'path/to/credentials.json'
+]);
+```
+
+To generate a credentials json file for your service account:
+
+*   In the Firebase console, open **Settings** > [Service Accounts](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk).
+*   Click **Generate New Private Key**, then confirm by clicking **Generate Key**.
+*   Securely store the JSON file containing the key.
 
 
 The default configuration parameters for **APN** are:
@@ -117,6 +140,11 @@ For FCM Service:
 $push = new PushNotification('fcm');
 ```
 
+For FCMV1 Service:
+```php
+$push = new PushNotification('fcmv1');
+```
+
 Now you may use any method that you need. Please see the API List.
 
 
@@ -138,6 +166,11 @@ Now you may use any method that you need. Please see the API List.
 ### Only for Fcm
 
 - [sendByTopic](https://github.com/edujugon/PushNotification#sendbytopic)
+
+### Only for Fcmv1
+
+- [setProjectId](https://github.com/edujugon/PushNotification#setprojectid)
+- [setJsonFile](https://github.com/edujugon/PushNotification#setjsonfile)
 
 > Go to [Usage samples](https://github.com/edujugon/PushNotification#usage-samples) directly.
 
@@ -171,6 +204,30 @@ object setMessage(array $data)
 
 ```php
 object setApiKey($api_key)
+```
+
+#### setProjectId
+
+> Only for fcmv1
+
+`setProjectId` method sets the Project ID of your App as a string.
+
+**Syntax**
+
+```php
+object setProjectId($project_id)
+```
+
+#### setJsonFile
+
+> Only for fcmv1
+
+`setJsonFile` method sets the path of credentials json file of your App.
+
+**Syntax**
+
+```php
+object setJsonFile($api_key)
 ```
 
 #### setDevicesToken

--- a/src/Channels/FcmV1Channel.php
+++ b/src/Channels/FcmV1Channel.php
@@ -2,6 +2,8 @@
 
 namespace Edujugon\PushNotification\Channels;
 
+use Edujugon\PushNotification\Messages\PushMessage;
+
 class FcmV1Channel extends GcmChannel
 {
     /**
@@ -10,5 +12,60 @@ class FcmV1Channel extends GcmChannel
     protected function pushServiceName()
     {
         return 'fcmv1';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildData(PushMessage $message)
+    {
+        $data = [];
+
+        if ($message->title != null || $message->body != null) {
+            $data = [
+                'notification' => [
+                    'title' => $message->title,
+                    'body' => $message->body,
+                ],
+            ];
+        }
+
+        if (
+            $message->icon ||
+            $message->color ||
+            $message->sound ||
+            $message->click_action ||
+            $message->badge
+        ) {
+            $data['android'] = [
+                'notification' => []
+            ];
+
+            if (! empty($message->icon)) {
+                $data['android']['notification']['icon'] = $message->icon;
+            }
+
+            if (! empty($message->color)) {
+                $data['android']['notification']['color'] = $message->color;
+            }
+
+            if (! empty($message->sound)) {
+                $data['android']['notification']['sound'] = $message->sound;
+            }
+
+            if (! empty($message->click_action)) {
+                $data['android']['notification']['click_action'] = $message->click_action;
+            }
+
+            if (! empty($message->badge)) {
+                $data['android']['notification']['notification_count'] = $message->badge;
+            }
+        }
+
+        if (! empty($message->extra)) {
+            $data['data'] = $message->extra;
+        }
+
+        return $data;
     }
 }

--- a/src/Channels/FcmV1Channel.php
+++ b/src/Channels/FcmV1Channel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Edujugon\PushNotification\Channels;
+
+class FcmChannel extends GcmChannel
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function pushServiceName()
+    {
+        return 'fcmv1';
+    }
+}

--- a/src/Channels/FcmV1Channel.php
+++ b/src/Channels/FcmV1Channel.php
@@ -2,7 +2,7 @@
 
 namespace Edujugon\PushNotification\Channels;
 
-class FcmChannel extends GcmChannel
+class FcmV1Channel extends GcmChannel
 {
     /**
      * {@inheritdoc}

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @see https://github.com/Edujugon/PushNotification
  */
@@ -16,6 +17,15 @@ return [
         'priority' => 'normal',
         'dry_run' => false,
         'apiKey' => 'My_ApiKey',
+        // Optional: Default Guzzle request options for each FCM request
+        // See https://docs.guzzlephp.org/en/stable/request-options.html
+        'guzzle' => [],
+    ],
+    'fcmv1' => [
+        'priority' => 'normal',
+        'dry_run' => false,
+        'projectId' => 'my-project-id',
+        'jsonFile' => __DIR__ . '/fcmCertificates/file.json',
         // Optional: Default Guzzle request options for each FCM request
         // See https://docs.guzzlephp.org/en/stable/request-options.html
         'guzzle' => [],

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -26,6 +26,7 @@ return [
         'dry_run' => false,
         'projectId' => 'my-project-id',
         'jsonFile' => __DIR__ . '/fcmCertificates/file.json',
+        // 'concurrentRequests' => 5, // Optional, default 10
         // Optional: Default Guzzle request options for each FCM request
         // See https://docs.guzzlephp.org/en/stable/request-options.html
         'guzzle' => [],

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -26,6 +26,8 @@ return [
         'dry_run' => false,
         'projectId' => 'my-project-id',
         'jsonFile' => __DIR__ . '/fcmCertificates/file.json',
+        // 'credentials_cache_seconds' => 55 * 60, // Optional. Credentials cache time in seconds. Maximum 60*60 seconds.
+        // 'cache_store' => null, // Optional. Cache store name. Null for default
         // 'concurrentRequests' => 5, // Optional, default 10
         // Optional: Default Guzzle request options for each FCM request
         // See https://docs.guzzlephp.org/en/stable/request-options.html

--- a/src/FcmV1.php
+++ b/src/FcmV1.php
@@ -134,7 +134,7 @@ class FcmV1 extends Fcm
                     'error' => $error,
                 ];
 
-                if (isset($error['error']['status']) && $error['error']['status'] === 'INVALID_ARGUMENT') {
+                if (isset($error['error']['code']) && in_array($error['error']['code'], [400, 404])) {
                     $this->unregisteredDeviceTokens[] = $deviceToken;
                 }
             },

--- a/src/FcmV1.php
+++ b/src/FcmV1.php
@@ -146,7 +146,7 @@ class FcmV1 extends Fcm
                     'error' => $error,
                 ];
 
-                if (isset($error['error']['code']) && in_array($error['error']['code'], [400, 404])) {
+                if (isset($error['error']['code']) && $error['error']['code'] === 404) {
                     $this->unregisteredDeviceTokens[] = $deviceToken;
                 }
             },

--- a/src/FcmV1.php
+++ b/src/FcmV1.php
@@ -17,6 +17,8 @@ use Illuminate\Support\Str;
 
 class FcmV1 extends Fcm
 {
+    const BASE_URL = 'https://fcm.googleapis.com/v1/projects/';
+
     const DEFAULT_CREDENTIALS_CACHE_SECONDS = 55 * 60; // 55 minutes
 
     /**
@@ -47,7 +49,7 @@ class FcmV1 extends Fcm
     {
         $this->config = $this->initializeConfig('fcmv1');
 
-        $this->url = 'https://fcm.googleapis.com/v1/projects/' . $this->config['projectId'] . '/messages:send';
+        $this->url = self::BASE_URL . $this->config['projectId'] . '/messages:send';
 
         $this->client = new Client($this->config['guzzle'] ?? []);
 
@@ -75,7 +77,7 @@ class FcmV1 extends Fcm
     {
         $this->config['projectId'] = $projectId;
 
-        $this->url = 'https://fcm.googleapis.com/v1/projects/' . $this->config['projectId'] . '/messages:send';
+        $this->url = self::BASE_URL . $this->config['projectId'] . '/messages:send';
     }
 
     /**

--- a/src/FcmV1.php
+++ b/src/FcmV1.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Edujugon\PushNotification;
+
+use Carbon\Carbon;
+use Edujugon\PushNotification\Fcm;
+use Exception;
+use Google\Client as GoogleClient;
+use Google\Service\FirebaseCloudMessaging;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class FcmV1 extends Fcm
+{
+    const CACHE_SECONDS = 55 * 60; // 55 minutes
+
+    /**
+     * Fcm constructor.
+     * Override parent constructor.
+     */
+    public function __construct()
+    {
+        $this->config = $this->initializeConfig('fcmv1');
+
+        $this->url = 'https://fcm.googleapis.com/v1/projects/' . $this->config['projectId'] . '/messages:send';
+
+        $this->client = new Client($this->config['guzzle'] ?? []);
+    }
+
+    /**
+     * Set the apiKey for the notification
+     * @param string $apiKey
+     */
+    public function setApiKey($apiKey)
+    {
+        throw new Exception('Not available on FCM V1');
+    }
+
+    /**
+     * Set the projectId for the notification
+     * @param string $projectId
+     */
+    public function setProjectId($projectId)
+    {
+        $this->config['projectId'] = $projectId;
+
+        $this->url = 'https://fcm.googleapis.com/v1/projects/' . $this->config['projectId'] . '/messages:send';
+    }
+
+    /**
+     * Set the jsonFile path for the notification
+     * @param string $jsonFile
+     */
+    public function setJsonFile($jsonFile)
+    {
+        $this->config['jsonFile'] = $jsonFile;
+    }
+
+    /**
+     * Set the needed headers for the push notification.
+     *
+     * @return array
+     */
+    protected function addRequestHeaders()
+    {
+        return [
+            'Authorization' => 'Bearer ' . $this->getOauthToken(),
+            'Content-Type' =>  'application/json',
+        ];
+    }
+
+    /**
+     * Send Push Notification
+     *
+     * @param  array $deviceTokens
+     * @param array $message
+     *
+     * @return \stdClass  GCM Response
+     */
+    public function send(array $deviceTokens, array $message)
+    {
+        // FCM v1 does not allows multiple devices at once
+
+        $headers = $this->addRequestHeaders();
+        $jsonData = ['message' => $this->buildMessage($message)];
+
+        $feedbacks = [];
+
+        foreach ($deviceTokens as $deviceToken) {
+            try {
+                $jsonData['message']['token'] = $deviceToken;
+
+                $result = $this->client->post(
+                    $this->url,
+                    [
+                        'headers' => $headers,
+                        'json' => $jsonData,
+                    ]
+                );
+
+                $json = $result->getBody();
+
+                $feedbacks[] = json_decode($json, false, 512, JSON_BIGINT_AS_STRING);
+            } catch (ClientException $e) {
+                $feedbacks[] = ['success' => false, 'error' => json_encode($e->getResponse())];
+            } catch (\Exception $e) {
+                $feedbacks[] = ['success' => false, 'error' => $e->getMessage()];
+            }
+        }
+
+        $this->setFeedback($feedbacks);
+    }
+
+    /**
+     * Prepare the data to be sent
+     *
+     * @param $topic
+     * @param $message
+     * @param $isCondition
+     * @return array
+     */
+    protected function buildData($topic, $message, $isCondition)
+    {
+        $condition = $isCondition ? ['condition' => $topic] : ['to' => '/topics/' . $topic];
+
+        return [
+            'message' => array_merge($condition, $this->buildMessage($message)),
+        ];
+    }
+
+    protected function getOauthToken()
+    {
+        return Cache::remember(
+            Str::slug('fcm-v1-oauth-token-' . $this->config['projectId']),
+            Carbon::now()->addSeconds(self::CACHE_SECONDS),
+            function () {
+                $jsonFilePath = $this->config['jsonFile'];
+
+                $googleClient = new GoogleClient();
+
+                $googleClient->setAuthConfig($jsonFilePath);
+                $googleClient->addScope(FirebaseCloudMessaging::FIREBASE_MESSAGING);
+
+                $accessToken = $googleClient->fetchAccessTokenWithAssertion();
+
+                $oauthToken = $accessToken['access_token'];
+
+                return $oauthToken;
+            }
+        );
+    }
+}

--- a/src/FcmV1.php
+++ b/src/FcmV1.php
@@ -75,6 +75,18 @@ class FcmV1 extends Fcm
     }
 
     /**
+     * Update the values by key on config array from the passed array. If any key doesn't exist, it's added.
+     * @param array $config
+     */
+    public function setConfig(array $config)
+    {
+        parent::setConfig($config);
+
+        // Update url
+        $this->setProjectId($this->config['projectId']);
+    }
+
+    /**
      * Set the needed headers for the push notification.
      *
      * @return array

--- a/src/PushNotification.php
+++ b/src/PushNotification.php
@@ -18,7 +18,8 @@ class PushNotification
     protected $servicesList = [
         'gcm' => Gcm::class,
         'apn' => Apn::class,
-        'fcm' => Fcm::class
+        'fcm' => Fcm::class,
+        'fcmv1' => FcmV1::class,
     ];
 
     /**


### PR DESCRIPTION
Add service to use FCM HTTP v1 API.

According to Google (https://firebase.google.com/docs/cloud-messaging/migrate-v1)

> Apps using the deprecated FCM legacy APIs for HTTP and XMPP should migrate to the HTTP v1 API at the earliest opportunity. Sending messages (including upstream messages) with those APIs was deprecated on June 20, 2023, and will be removed in June 2024.




